### PR TITLE
Update preview action source and environment variables

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -11,14 +11,14 @@ jobs:
     name: Publish Preview Package
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
         registry-url: https://registry.npmjs.org
     - name: NPM Publish Preview
-      uses: thefrontside/actions/publish-pr-preview@main
+      uses: thefrontside/actions/publish-pr-preview@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Tag and Publish
       uses: thefrontside/actions/synchronize-with-npm@v1.9
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/synchronize-npm-tags.yml
+++ b/.github/workflows/synchronize-npm-tags.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/checkout@v1
     - uses: thefrontside/actions/synchronize-npm-tags@v1.1
       env:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation

This is part of an effort to finalize [@thefrontside/actions #68](https://github.com/thefrontside/actions/issues/68) by moving all actions being called from the `main` branch to move over to `v2`.

## Approach

- Updated action source
- Checkout needed to be upgraded to `v3` too due to [@thefrontside/actions #73](https://github.com/thefrontside/actions/pull/73)
- Replaced npm and github tokens with organization secrets (you can see them [here](https://github.com/thefrontside/microstates/settings/secrets/actions))